### PR TITLE
Add support for iPhone X on both simulator and device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.3.0
+#### 2016/09/15
+
+- Added support for iPhone X, iPhone 8 and iPhone 8 Plus versions
+
 # Version 0.2.1
 #### 2016/09/15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version 0.3.0
-#### 2016/09/15
+#### 2017/10/31
 
 - Added support for iPhone X, iPhone 8 and iPhone 8 Plus versions
 

--- a/MDResourceManager.podspec
+++ b/MDResourceManager.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "MDResourceManager"
-  s.version          = "0.2.1"
+  s.version          = "0.3.0"
   s.summary          = "iOS Resource Management, the Android way"
   s.description      = <<-DESC
                        Provide resources independently of your code. Manage different sizes, strings depending on the device type or orientation.

--- a/Pod/Classes/Util/MDDeviceUtil.m
+++ b/Pod/Classes/Util/MDDeviceUtil.m
@@ -74,6 +74,12 @@
                               @"iPhone9,3" :@"iphone6",     // iPhone 7
                               @"iPhone9,2" :@"iphone6plus", // iPhone 7 Plus
                               @"iPhone9,4" :@"iphone6plus", // iPhone 7 Plus
+                              @"iPhone10,1" :@"iphone6",    // iPhone 8
+                              @"iPhone10,4" :@"iphone6",    // iPhone 8
+                              @"iPhone10,2" :@"iphone6plus",// iPhone 8 Plus
+                              @"iPhone10,5" :@"iphone6plus",// iPhone 8 Plus
+                              @"iPhone10,3" :@"iphonex",    // iPhone X
+                              @"iPhone10,6" :@"iphonex",    // iPhone X
                               @"i386"      :@"simulator",
                               @"x86_64"    :@"simulator",
                               
@@ -153,6 +159,9 @@
     } else if(screenHeight == 736) {
         
         return @"iphone6plus";
+    } else if (screenHeight == 812) {
+        
+        return @"iphonex";
     } else {
      
         return @"iphone";


### PR DESCRIPTION
Identify iPhone 8 and 8 plus as 6 and 6 plus (same dimensions)